### PR TITLE
Allow install in subpath

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -2,5 +2,5 @@ SOURCE_URL=https://github.com/SSilence/selfoss/releases/download/2.18/selfoss-2.
 SOURCE_SUM=0b3d46b0b25170f99e3e29c9fc6a2e5235b0449fecbdad902583c919724aa6ed
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
-SOURCE_IN_SUBDIR=false
+SOURCE_IN_SUBDIR=true
 SOURCE_EXTRACT=true


### PR DESCRIPTION
Hi @ericgaspar, here is a quick PR to allow installation in a subpath. Since now, I get Selfoss to work on /selfoss parh on my server.