### PR TITLE
Selfoss 2.19 zip have a subfolder 'selfoss'

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -2,5 +2,5 @@ SOURCE_URL=https://github.com/SSilence/selfoss/releases/download/2.19/selfoss-2.
 SOURCE_SUM=e49c4750e9723277963ca699b602f09f9148e2b9f258fce6b14429498af0e4fc
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
-SOURCE_IN_SUBDIR=false
+SOURCE_IN_SUBDIR=true
 SOURCE_EXTRACT=true


### PR DESCRIPTION
Now I understood the usage of `SOURCE_IN_SUBDIR=true`, I can tell that Selfoss 2.19 zip needs it :+1: 